### PR TITLE
Added a default folder name argument to print_html()

### DIFF
--- a/index.php
+++ b/index.php
@@ -145,7 +145,7 @@ foreach(glob($dir, GLOB_ONLYDIR) as $folder)
 
 echo '</div>';
 
-function print_html($folder, $file, $file_path, $folder_name) {
+function print_html($folder, $file, $file_path, $folder_name = null) {
 	$file_id = strtolower(remove_chars($file_path['filename']));
 	$file_contents = file_get_contents($file);
 	$css_file = $folder . '/' . $file_path['filename'] . '.css';


### PR DESCRIPTION
Calls to print_html() could cause the display of PHP errors due to a
missing argument in line 140.
